### PR TITLE
Refactor Vignette.Camera

### DIFF
--- a/Vignette.Camera/Camera.cs
+++ b/Vignette.Camera/Camera.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Emgu.CV;
 using Emgu.CV.CvEnum;
-using Emgu.CV.Structure;
 using Emgu.CV.Util;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Logging;

--- a/Vignette.Camera/Platform/LinuxCameraManager.cs
+++ b/Vignette.Camera/Platform/LinuxCameraManager.cs
@@ -26,8 +26,7 @@ namespace Vignette.Camera.Platform
 
                 if (File.Exists(friendlyNamePath))
                 {
-                    using var reader = new StreamReader(File.OpenRead(friendlyNamePath));
-                    friendlyName = reader.ReadToEnd();
+                    friendlyName = $"({i}) {File.ReadAllText(friendlyNamePath).TrimEnd('\n')}";
                 }
                 else
                 {

--- a/Vignette.Camera/Platform/LinuxCameraManager.cs
+++ b/Vignette.Camera/Platform/LinuxCameraManager.cs
@@ -17,7 +17,7 @@ namespace Vignette.Camera.Platform
 
         protected override IEnumerable<CameraInfo> EnumerateAllDevices()
         {
-            for (int i = 0; i < Directory.EnumerateDirectories(@"/dev/").Count(); i++)
+            for (int i = 0; i < Directory.EnumerateDirectories("/dev/").Count(); i++)
             {
                 string path = $"/dev/video{i}";
 

--- a/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
+++ b/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
@@ -215,12 +215,12 @@ namespace Vignette.Game.Graphics.UserInterface
         {
             if (itemMap.ContainsKey(item))
             {
-                /* throw new ArgumentException($"The item {item} already exists in this {nameof(FluentDropdown<T>)}."); */
-                Logger.Log(
-                    $"\x1b[33mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m",
-                    LoggingTarget.Runtime, LogLevel.Important
-                );
-                return;
+                throw new ArgumentException($"The item {item} already exists in this {nameof(FluentDropdown<T>)}.");
+                /* Logger.Log( */
+                /*     $"\x1b[33mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m", */
+                /*     LoggingTarget.Runtime, LogLevel.Important */
+                /* ); */
+                /* return; */
             }
 
             var menuItem = new FluentMenuItem(text, () =>

--- a/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
+++ b/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osuTK;
 using Vignette.Game.Extensions;
 using Vignette.Game.Graphics.Containers;
@@ -215,7 +216,10 @@ namespace Vignette.Game.Graphics.UserInterface
             if (itemMap.ContainsKey(item))
             {
                 /* throw new ArgumentException($"The item {item} already exists in this {nameof(FluentDropdown<T>)}."); */
-                System.Console.WriteLine($"\x1b[33mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m");
+                Logger.Log(
+                    $"\x1b[33mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m",
+                    LoggingTarget.Runtime, LogLevel.Important
+                );
                 return;
             }
 

--- a/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
+++ b/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
@@ -215,7 +215,7 @@ namespace Vignette.Game.Graphics.UserInterface
             if (itemMap.ContainsKey(item))
             {
                 /* throw new ArgumentException($"The item {item} already exists in this {nameof(FluentDropdown<T>)}."); */
-                System.Console.WriteLine($"\x1b[32mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m");
+                System.Console.WriteLine($"\x1b[33mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m");
                 return;
             }
 

--- a/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
+++ b/Vignette.Game/Graphics/UserInterface/FluentDropdown.cs
@@ -213,7 +213,11 @@ namespace Vignette.Game.Graphics.UserInterface
         private void addItem(LocalisableString text, T item)
         {
             if (itemMap.ContainsKey(item))
-                throw new ArgumentException($"The item {item} already exists in this {nameof(FluentDropdown<T>)}.");
+            {
+                /* throw new ArgumentException($"The item {item} already exists in this {nameof(FluentDropdown<T>)}."); */
+                System.Console.WriteLine($"\x1b[32mWarning: item {item} already exists in this {nameof(FluentDropdown<T>)}. Not adding it again.\x1b[0m");
+                return;
+            }
 
             var menuItem = new FluentMenuItem(text, () =>
             {

--- a/Vignette.Game/Settings/Sections/RecognitionSection.cs
+++ b/Vignette.Game/Settings/Sections/RecognitionSection.cs
@@ -51,6 +51,10 @@ namespace Vignette.Game.Settings.Sections
                 },
             };
 
+            System.Console.WriteLine("\n\x1b[34m==== Camera device names ====");
+            foreach (var cdn in camera.CameraDeviceNames)
+                System.Console.WriteLine(cdn);
+            System.Console.WriteLine("==== Camera device names ====\x1b[0m");
             devices.AddRange(camera.CameraDeviceNames);
             camera.OnNewDevice += onNewCameraDevice;
             camera.OnLostDevice += onLostCameraDevice;

--- a/Vignette.Game/Settings/Sections/RecognitionSection.cs
+++ b/Vignette.Game/Settings/Sections/RecognitionSection.cs
@@ -51,10 +51,6 @@ namespace Vignette.Game.Settings.Sections
                 },
             };
 
-            System.Console.WriteLine("\n\x1b[34m==== Camera device names ====");
-            foreach (var cdn in camera.CameraDeviceNames)
-                System.Console.WriteLine(cdn);
-            System.Console.WriteLine("==== Camera device names ====\x1b[0m");
             devices.AddRange(camera.CameraDeviceNames);
             camera.OnNewDevice += onNewCameraDevice;
             camera.OnLostDevice += onLostCameraDevice;


### PR DESCRIPTION
This PR fixes issue #234.

The previous solution that I've implemented is simply not adding a duplicate item in the FluentDropdown, and warning about it with a console write statement.
![image](https://user-images.githubusercontent.com/13885008/135649704-50ace6fd-dc86-41d7-929a-8645505294d3.png)
![image](https://user-images.githubusercontent.com/13885008/135649791-7d88cc26-7672-449e-8baa-79b16552d650.png)

Now, the solution is indexing the friendly names so that all options pop up.
We're now faced with a "can't open camera by index" bug.