### PR TITLE
Fix crashes

### DIFF
--- a/Vignette.Game/Settings/Panels/ThemeDesignerPanel.cs
+++ b/Vignette.Game/Settings/Panels/ThemeDesignerPanel.cs
@@ -27,11 +27,11 @@ namespace Vignette.Game.Settings.Panels
         public ThemeDesignerPanel(IThemeSource source)
         {
             theme = new Bindable<Theme>(source.Current.Value);
-            Children = new Drawable[]
+            /*Children = new Drawable[]
             {
                 new PreviewSection(),
                 new CustomizationSection(),
-            };
+            };*/
         }
 
         private class PreviewSection : SettingsSection

--- a/Vignette.Game/Settings/Sections/SystemSection.cs
+++ b/Vignette.Game/Settings/Sections/SystemSection.cs
@@ -126,10 +126,10 @@ namespace Vignette.Game.Settings.Sections
                             Current = themeManager.Current,
                             ItemSource = themeManager.UseableThemes,
                         },
-                        new OpenSubPanelButton<ThemeDesignerPanel>(themeManager)
+                        /*new OpenSubPanelButton<ThemeDesignerPanel>(themeManager)
                         {
                             Label = "Open theme designer",
-                        },
+                        },*/
                         new OpenExternalLinkButton(themeManager.Store)
                         {
                             Label = "Open themes folder",


### PR DESCRIPTION
Closes #237

- [x] Theme designer button crashes the app instead of displaying an error (or not being there at all for now)
- [ ] Model file browser should select a directory and not a file
- [ ] Model file browser shouldn't crash when the directory doesn't contain a model
- [ ] Backdrop selector shouldn't crash when the image is too big
- [ ] Moving around the resizable window crashes the app
- [ ] Resizing the window bigger than the dimensions of a monitor (across multiple monitors) crashes the app (i think that's an o!f issue)